### PR TITLE
Overeager conflicts when target is empty

### DIFF
--- a/lib/generate-where-clause.js
+++ b/lib/generate-where-clause.js
@@ -19,7 +19,7 @@ function fieldExpression (table, field, filterObj, inverted) {
     .map(cmp => filterExpression(table, field, cmp, filterObj[cmp], inverted))
   const expression = exprs.join(!inverted ? ' AND ' : ' OR ')
 
-  return (filters.length == 1)
+  return (filters.length === 1)
     ? expression
     : `(${expression})`
 } // fieldExpression

--- a/lib/generate-where-clause.js
+++ b/lib/generate-where-clause.js
@@ -10,25 +10,30 @@ function whereClause (filter, tableName = null, inverted = false) {
 
   const where = filterExpressions.join(' AND ')
 
-  return inverted ? `not(${where})` : where
+  return where
 } // generateWhereClause
 
 function fieldExpression (table, field, filterObj, inverted) {
-  const exprs = Object.keys(filterObj)
+  const filters = Object.keys(filterObj)
+  const exprs = filters
     .map(cmp => filterExpression(table, field, cmp, filterObj[cmp], inverted))
-  return exprs.join(' AND ')
+  const expression = exprs.join(!inverted ? ' AND ' : ' OR ')
+
+  return (filters.length == 1)
+    ? expression
+    : `(${expression})`
 } // fieldExpression
 
 function filterExpression (table, field, cmp, value, inverted) {
   if (Array.isArray(value)) {
     const orExprs = value.map(v => filterExpression(table, field, cmp, v, inverted))
-    return `(${orExprs.join(' OR ')})`
+    return `(${orExprs.join(!inverted ? ' OR ' : ' AND ')})`
   }
 
   const fullFieldName = `${table}${field}`
-  const comparator = comparatorLookup(cmp)
+  const comparator = comparatorLookup(cmp, inverted)
   const escapedValue = sqlEscape(value)
-  const notNull = notNullQualifier(fullFieldName, cmp, value)
+  const notNull = notNullQualifier(fullFieldName, cmp, value, inverted)
 
   const expression = `${fullFieldName}${comparator}${escapedValue}`
 
@@ -37,10 +42,10 @@ function filterExpression (table, field, cmp, value, inverted) {
     : expression
 } // filterExpression
 
-function notNullQualifier (fullFieldName, comparator, value) {
+function notNullQualifier (fullFieldName, comparator, value, inverted) {
   if (comparator !== 'equals' || typeof value !== 'string') return null
 
-  return ` and ${fullFieldName} is not null`
+  return !inverted ? ` and ${fullFieldName} is not null` : ` or ${fullFieldName} is null`
 }
 
 const Comparators = {
@@ -51,8 +56,16 @@ const Comparators = {
   lessThanEquals: ' <= '
 }
 
-function comparatorLookup (cmp) {
-  const comparator = Comparators[cmp]
+const InvertedComparators = {
+  equals: ' != ',
+  moreThan: ' <= ',
+  lessThan: ' >= ',
+  moreThanEquals: ' < ',
+  lessThanEquals: ' > '
+}
+
+function comparatorLookup (cmp, inverted) {
+  const comparator = !inverted ? Comparators[cmp] : InvertedComparators[cmp]
 
   if (!comparator) throw new Error(`${cmp} is an unknown comparison in the where filter object`)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ async function createDirectories (options) {
   }
 } // createDirectories
 
-async function potentialConflicts(options) {
+async function potentialConflicts (options) {
   if (!options.target.where) {
     return false
   }
@@ -61,7 +61,7 @@ async function potentialConflicts(options) {
   const countSql = `select count(*) as count from ${options.target.tableName} target where ${filter}`
 
   const countResult = await options.client.query(countSql)
-  const potential = (countResult.rows[0].count !== "0")
+  const potential = (countResult.rows[0].count !== '0')
   return potential
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const processUpserts = require('./process-upserts')
 const processConflicts = require('./process-conflicts')
 const processDeletes = require('./process-deletes')
 const syncChanges = require('./sync-changes')
+const generateWhereClause = require('./generate-where-clause')
 
 async function pgTelepods (options) {
   debug('Start')
@@ -24,7 +25,7 @@ async function pgTelepods (options) {
   debug('Finding deletes ...')
   await processDeletes(options)
 
-  if (options.target.where) {
+  if (await potentialConflicts(options)) {
     debug('Finding conflicts ...')
     await processConflicts(options)
   }
@@ -50,6 +51,19 @@ async function createDirectories (options) {
     await makeDir(dir)
   }
 } // createDirectories
+
+async function potentialConflicts(options) {
+  if (!options.target.where) {
+    return false
+  }
+
+  const filter = generateWhereClause(options.target.where, 'target')
+  const countSql = `select count(*) as count from ${options.target.tableName} target where ${filter}`
+
+  const countResult = await options.client.query(countSql)
+  const potential = (countResult.rows[0].count !== "0")
+  return potential
+}
 
 function dbgOptions (options) {
   debug({

--- a/lib/process-conflicts.js
+++ b/lib/process-conflicts.js
@@ -6,9 +6,12 @@ function conflictCondition (
   targetHashCol,
   options
 ) {
+  const targetPk = Object.values(options.join)
+  const pkIsNotNull = targetPk.map(k => `target.${k} is not null`).join(' and ')
+
   const filter = generateWhereClause.inverted(options.target.where, 'target')
 
-  return `(target.${targetHashCol} is null or source.${sourceHashCol} != target.${targetHashCol}) and ${filter}`
+  return `(${pkIsNotNull}) and (target.${targetHashCol} is null or source.${sourceHashCol} != target.${targetHashCol}) and ${filter}`
 }
 
 function processConflicts (options) {

--- a/test/full-table-tests.js
+++ b/test/full-table-tests.js
@@ -101,7 +101,7 @@ describe('whole-table test',
       expect(deletes.split('\n').length).to.equal(7)
     })
 
-    it ('check no conflicts', () => {
+    it('check no conflicts', () => {
       const censusConflicts = path.resolve(firstSyncOutputDir, 'conflicts', 'census.csv')
       expect(fs.existsSync(censusConflicts)).to.equal(false)
     })

--- a/test/full-table-tests.js
+++ b/test/full-table-tests.js
@@ -101,6 +101,11 @@ describe('whole-table test',
       expect(deletes.split('\n').length).to.equal(7)
     })
 
+    it ('check no conflicts', () => {
+      const censusConflicts = path.resolve(firstSyncOutputDir, 'conflicts', 'census.csv')
+      expect(fs.existsSync(censusConflicts)).to.equal(false)
+    })
+
     after('uninstall test schemas', () => {
       return client.runFile(path.resolve(__dirname, 'fixtures', 'uninstall-test-schemas.sql'))
     })

--- a/test/partial-table-tests-population.js
+++ b/test/partial-table-tests-population.js
@@ -1,0 +1,406 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const HlPgClient = require('@wmfs/hl-pg-client')
+const startTelepods = require('./../lib')
+const process = require('process')
+const chai = require('chai')
+const expect = chai.expect
+const path = require('path')
+const fs = require('fs')
+
+function checkFileLength (outputDir, operation, filename, expectedLength) {
+  const censusDeletes = path.resolve(outputDir, operation, filename)
+  expect(fs.existsSync(censusDeletes)).to.equal(true)
+
+  const deletes = fs.readFileSync(censusDeletes, { encoding: 'utf-8' })
+  expect(deletes.split('\n').length).to.equal(expectedLength)
+}
+
+describe('partial-table test',
+  function () {
+    // this.timeout(process.env.TIMEOUT || 5000)
+    let client
+
+    before(function () {
+      if (process.env.PG_CONNECTION_STRING && !/^postgres:\/\/[^:]+:[^@]+@(?:localhost|127\.0\.0\.1).*$/.test(process.env.PG_CONNECTION_STRING)) {
+        console.log(`Skipping tests due to unsafe PG_CONNECTION_STRING value (${process.env.PG_CONNECTION_STRING})`)
+        this.skip()
+      }
+    })
+
+    before('create a new pg client', () => {
+      client = new HlPgClient(process.env.PG_CONNECTION_STRING)
+    })
+
+    before('install test schemas', () => {
+      return client.runFile(path.resolve(__dirname, 'fixtures', 'install-test-schemas.sql'))
+    })
+
+    const firstSyncOutputDir = path.resolve(__dirname, './output', 'first-partial')
+    const secondSyncOutputDir = path.resolve(__dirname, './output', 'second-partial')
+    const thirdSyncOutputDir = path.resolve(__dirname, './output', 'partial-with-hash-conflict')
+    const fourthSyncOutputDir = path.resolve(__dirname, './output', 'partial-with-null-hash-conflict')
+    const fifthSyncOutputDir = path.resolve(__dirname, './output', 'partial-with-null-town-conflict')
+
+    describe('sync first table', () => {
+      it('start the telepods', async () => {
+        const result = await startTelepods({
+          client: client,
+          outputDir: firstSyncOutputDir,
+          source: {
+            tableName: 'springfield.people',
+            hashSumColumnName: 'hash_sum'
+          },
+          target: {
+            tableName: 'government.census',
+            hashSumColumnName: 'origin_hash_sum',
+            where: {
+              town: { equals: 'Springfield' }
+            }
+          },
+          join: {
+            social_security_id: 'id_number' // key = source table column, value = target table column
+          },
+          transformFunction: function (sourceRow, callback) {
+            callback(null, {
+              id_number: sourceRow.socialSecurityId,
+              name: `${sourceRow.firstName} ${sourceRow.lastName}`,
+              town: 'Springfield'
+            })
+          }
+        })
+        expect(result).to.not.equal(null)
+      })
+
+      it('verify modified children rows', async () => {
+        const result = await client.query(
+          'select id_number, origin_hash_sum, name, town from government.census order by id_number'
+        )
+        expect(result).to.not.equal(null)
+        expect(result.rows).to.eql(
+          [
+            {
+              name: 'Homer Simpson',
+              origin_hash_sum: 'AAAAAAAA',
+              id_number: 1,
+              town: 'Springfield'
+            },
+            {
+              name: 'Marge Simpson',
+              origin_hash_sum: 'BBBBBBBB',
+              id_number: 2,
+              town: 'Springfield'
+            },
+            {
+              name: 'Montgomery Burns',
+              origin_hash_sum: 'EEEEEEEE',
+              id_number: 5,
+              town: 'Springfield'
+            },
+            {
+              name: 'Ned Flanders',
+              origin_hash_sum: '11111111',
+              id_number: 6,
+              town: 'Springfield'
+            },
+            {
+              name: 'Phillip Fry',
+              origin_hash_sum: 'ABCDEFGH',
+              id_number: 20,
+              town: 'New New York'
+            },
+            {
+              name: 'Leela',
+              origin_hash_sum: 'DEFGHIJK',
+              id_number: 21,
+              town: 'New New York'
+            },
+            {
+              name: 'Doctor Zoidburg',
+              origin_hash_sum: 'ZZZZZZZZ',
+              id_number: 38,
+              town: 'New New York'
+            }
+          ]
+        )
+      })
+
+      it('check for inserts csv', () => {
+        checkFileLength(firstSyncOutputDir, 'inserts', 'census.csv', 4)
+      })
+
+      it('check for upserts csv', () => {
+        checkFileLength(firstSyncOutputDir, 'upserts', 'census.csv', 3)
+      })
+
+      it('check for deletes csv', () => {
+        checkFileLength(firstSyncOutputDir, 'deletes', 'census.csv', 4)
+      })
+    })
+
+    describe('sync second table', () => {
+      it('start the telepods', async () => {
+        const result = await startTelepods({
+          client: client,
+          outputDir: secondSyncOutputDir,
+          source: {
+            tableName: 'worldof.tomorrow',
+            hashSumColumnName: 'hash_sum'
+          },
+          target: {
+            tableName: 'government.census',
+            hashSumColumnName: 'origin_hash_sum',
+            where: {
+              town: { equals: 'New New York' }
+            }
+          },
+          join: {
+            space_id: 'id_number' // key = source table column, value = target table column
+          },
+          transformFunction: function (sourceRow, callback) {
+            callback(null, {
+              id_number: sourceRow.spaceId,
+              name: sourceRow.name,
+              town: 'New New York'
+            })
+          }
+        })
+        expect(result).to.not.equal(null)
+      })
+
+      it('verify modified children rows', async () => {
+        const result = await client.query(
+          'select id_number, origin_hash_sum, name, town from government.census order by id_number'
+        )
+        expect(result).to.not.equal(null)
+        expect(result.rows).to.eql(
+          [
+            {
+              name: 'Homer Simpson',
+              origin_hash_sum: 'AAAAAAAA',
+              id_number: 1,
+              town: 'Springfield'
+            },
+            {
+              name: 'Marge Simpson',
+              origin_hash_sum: 'BBBBBBBB',
+              id_number: 2,
+              town: 'Springfield'
+            },
+            {
+              name: 'Montgomery Burns',
+              origin_hash_sum: 'EEEEEEEE',
+              id_number: 5,
+              town: 'Springfield'
+            },
+            {
+              name: 'Ned Flanders',
+              origin_hash_sum: '11111111',
+              id_number: 6,
+              town: 'Springfield'
+            },
+            {
+              name: 'Philip J. Fry',
+              origin_hash_sum: 'ABCDEFGQ',
+              id_number: 20,
+              town: 'New New York'
+            },
+            {
+              name: 'Leela',
+              origin_hash_sum: 'DEFGHIJK',
+              id_number: 21,
+              town: 'New New York'
+            },
+            {
+              name: 'Professor Farnsworth',
+              origin_hash_sum: 'GHIJKLMN',
+              id_number: 22,
+              town: 'New New York'
+            },
+            {
+              name: 'Bender',
+              origin_hash_sum: 'AAAAAAAA',
+              id_number: 27,
+              town: 'New New York'
+            }
+          ]
+        )
+      })
+
+      it('check for inserts csv', () => {
+        checkFileLength(secondSyncOutputDir, 'inserts', 'census.csv', 4)
+      })
+
+      it('check for upserts csv', () => {
+        checkFileLength(secondSyncOutputDir, 'upserts', 'census.csv', 3)
+      })
+
+      it('check for deletes csv', () => {
+        checkFileLength(secondSyncOutputDir, 'deletes', 'census.csv', 3)
+      })
+    })
+
+    describe('sync conflict with hash_sum mismatch', () => {
+      it('create conflicting update row - matching primary key, changed hash, wrong city', async () => {
+        await client.query('update government.census set origin_hash_sum = \'QQQQ\', name = \'Lila\', town = \'Nowhere\' where id_number = 21')
+      })
+
+      it('start the telepods', async () => {
+        const result = await startTelepods({
+          client: client,
+          outputDir: thirdSyncOutputDir,
+          source: {
+            tableName: 'worldof.tomorrow',
+            hashSumColumnName: 'hash_sum'
+          },
+          target: {
+            tableName: 'government.census',
+            hashSumColumnName: 'origin_hash_sum',
+            where: {
+              town: { equals: 'New New York' }
+            }
+          },
+          join: {
+            space_id: 'id_number' // key = source table column, value = target table column
+          },
+          transformFunction: function (sourceRow, callback) {
+            callback(null, {
+              id_number: sourceRow.spaceId,
+              name: sourceRow.name,
+              town: 'New New York'
+            })
+          }
+        })
+        expect(result).to.not.equal(null)
+      })
+
+      it('check empty inserts csv', () => {
+        checkFileLength(thirdSyncOutputDir, 'inserts', 'census.csv', 1)
+      })
+
+      it('check empty upserts csv', () => {
+        checkFileLength(thirdSyncOutputDir, 'upserts', 'census.csv', 1)
+      })
+
+      it('check empty deletes csv', () => {
+        checkFileLength(thirdSyncOutputDir, 'deletes', 'census.csv', 2)
+      })
+
+      it('check conflict csv has one row', () => {
+        checkFileLength(thirdSyncOutputDir, 'conflicts', 'census.csv', 3)
+      })
+    })
+
+    describe('sync conflict with null target hash_sum', () => {
+      it('create conflicting insert row - matching primary key, null hash, but wrong city', async () => {
+        await client.query('update government.census set origin_hash_sum = null, name = \'Lila\', town = \'Nowhere\' where id_number = 21')
+      })
+
+      it('start the telepods', async () => {
+        const result = await startTelepods({
+          client: client,
+          outputDir: fourthSyncOutputDir,
+          source: {
+            tableName: 'worldof.tomorrow',
+            hashSumColumnName: 'hash_sum'
+          },
+          target: {
+            tableName: 'government.census',
+            hashSumColumnName: 'origin_hash_sum',
+            where: {
+              town: { equals: 'New New York' }
+            }
+          },
+          join: {
+            space_id: 'id_number' // key = source table column, value = target table column
+          },
+          transformFunction: function (sourceRow, callback) {
+            callback(null, {
+              id_number: sourceRow.spaceId,
+              name: sourceRow.name,
+              town: 'New New York'
+            })
+          }
+        })
+        expect(result).to.not.equal(null)
+      })
+
+      it('check empty inserts csv', () => {
+        checkFileLength(fourthSyncOutputDir, 'inserts', 'census.csv', 1)
+      })
+
+      it('check empty upserts csv', () => {
+        checkFileLength(fourthSyncOutputDir, 'upserts', 'census.csv', 1)
+      })
+
+      it('check empty deletes csv', () => {
+        checkFileLength(fourthSyncOutputDir, 'deletes', 'census.csv', 2)
+      })
+
+      it('check conflict csv has one row', () => {
+        checkFileLength(fourthSyncOutputDir, 'conflicts', 'census.csv', 3)
+      })
+    })
+
+    describe('sync conflict with null target hash_sum and null town', () => {
+      it('create conflicting insert row - matching primary key, null hash, but wrong city', async () => {
+        await client.query('update government.census set origin_hash_sum = null, name = \'Lila\', town = null where id_number = 21')
+      })
+
+      it('start the telepods', async () => {
+        const result = await startTelepods({
+          client: client,
+          outputDir: fifthSyncOutputDir,
+          source: {
+            tableName: 'worldof.tomorrow',
+            hashSumColumnName: 'hash_sum'
+          },
+          target: {
+            tableName: 'government.census',
+            hashSumColumnName: 'origin_hash_sum',
+            where: {
+              town: { equals: 'New New York' }
+            }
+          },
+          join: {
+            space_id: 'id_number' // key = source table column, value = target table column
+          },
+          transformFunction: function (sourceRow, callback) {
+            callback(null, {
+              id_number: sourceRow.spaceId,
+              name: sourceRow.name,
+              town: 'New New York'
+            })
+          }
+        })
+        expect(result).to.not.equal(null)
+      })
+
+      it('check empty inserts csv', () => {
+        checkFileLength(fifthSyncOutputDir, 'inserts', 'census.csv', 1)
+      })
+
+      it('check empty upserts csv', () => {
+        checkFileLength(fifthSyncOutputDir, 'upserts', 'census.csv', 1)
+      })
+
+      it('check empty deletes csv', () => {
+        checkFileLength(fifthSyncOutputDir, 'deletes', 'census.csv', 2)
+      })
+
+      it('check conflict csv has one row', () => {
+        checkFileLength(fifthSyncOutputDir, 'conflicts', 'census.csv', 3)
+      })
+    })
+
+    after('uninstall test schemas', () => {
+      return client.runFile(path.resolve(__dirname, 'fixtures', 'uninstall-test-schemas.sql'))
+    })
+
+    after('close database connections', () => {
+      client.end()
+    })
+  }
+)

--- a/test/partial-table-tests.js
+++ b/test/partial-table-tests.js
@@ -138,6 +138,10 @@ describe('partial-table test',
       it('check for deletes csv', () => {
         checkFileLength(firstSyncOutputDir, 'deletes', 'census.csv', 4)
       })
+
+      it('check for conflicts csv', () => {
+        checkFileLength(firstSyncOutputDir, 'conflicts', 'census.csv', 1) // cr
+      })
     })
 
     describe('sync second table', () => {
@@ -239,6 +243,10 @@ describe('partial-table test',
 
       it('check for deletes csv', () => {
         checkFileLength(secondSyncOutputDir, 'deletes', 'census.csv', 3)
+      })
+
+      it('check for conflicts csv', () => {
+        checkFileLength(secondSyncOutputDir, 'conflicts', 'census.csv', 1) // cr
       })
     })
 
@@ -345,7 +353,7 @@ describe('partial-table test',
     })
 
     describe('sync conflict with null target hash_sum and null town', () => {
-      it('create conflicting insert row - matching primary key, null hash, but wrong city', async () => {
+      it('create conflicting insert row - matching primary key, null hash, null city', async () => {
         await client.query('update government.census set origin_hash_sum = null, name = \'Lila\', town = null where id_number = 21')
       })
 

--- a/test/where-clause-tests.js
+++ b/test/where-clause-tests.js
@@ -10,51 +10,51 @@ describe('where clause generation', () => {
       label: 'equals string',
       where: { town: { equals: 'Springfield' } },
       expected: 'source.town = \'Springfield\'',
-      expectedInverted: 'not((source.town = \'Springfield\' and source.town is not null))',
+      expectedInverted: '(source.town != \'Springfield\' or source.town is null)',
       tableName: 'source'
     },
     {
       label: 'equals 10',
       where: { age: { equals: 10 } },
       expected: 'age = 10',
-      expectedInverted: 'not(age = 10)'
+      expectedInverted: 'age != 10'
     },
     {
       label: 'equals true',
       where: { flowers: { equals: true } },
       expected: 'flowers = true',
-      expectedInverted: 'not(flowers = true)'
+      expectedInverted: 'flowers != true'
     },
     {
       label: 'equals escaped string',
       where: { town: { equals: 'Spri\\ngfield' } },
       expected: 'source.town = E\'Spri\\\\ngfield\'',
-      expectedInverted: 'not((source.town = E\'Spri\\\\ngfield\' and source.town is not null))',
+      expectedInverted: '(source.town != E\'Spri\\\\ngfield\' or source.town is null)',
       tableName: 'source'
     },
     {
       label: 'equals O\'Reilly',
       where: { surname: { equals: 'O\'Reilly' } },
       expected: 'surname = \'O\'\'Reilly\'',
-      expectedInverted: 'not((surname = \'O\'\'Reilly\' and surname is not null))'
+      expectedInverted: '(surname != \'O\'\'Reilly\' or surname is null)'
     },
     {
       label: 'equals Smith or Jones',
       where: { surname: { equals: ['Smith', 'Jones'] } },
       expected: '(surname = \'Smith\' OR surname = \'Jones\')',
-      expectedInverted: 'not(((surname = \'Smith\' and surname is not null) OR (surname = \'Jones\' and surname is not null)))'
+      expectedInverted: '((surname != \'Smith\' or surname is null) AND (surname != \'Jones\' or surname is null))'
     },
     {
       label: 'greater than 5 and less than 10',
       where: { age: { moreThan: 5, lessThan: 10 } },
-      expected: 'age > 5 AND age < 10',
-      expectedInverted: 'not(age > 5 AND age < 10)'
+      expected: '(age > 5 AND age < 10)',
+      expectedInverted: '(age <= 5 OR age >= 10)'
     },
     {
       label: 'greater than or equal 0 and less than or equal 99',
       where: { age: { moreThanEquals: 0, lessThanEquals: 99 } },
-      expected: 'age >= 0 AND age <= 99',
-      expectedInverted: 'not(age >= 0 AND age <= 99)'
+      expected: '(age >= 0 AND age <= 99)',
+      expectedInverted: '(age < 0 OR age > 99)'
     },
     {
       label: 'equals Smith or Jones, greater than 5 and less than 10',
@@ -62,8 +62,8 @@ describe('where clause generation', () => {
         surname: { equals: ['Smith', 'Jones'] },
         age: { moreThan: 5, lessThan: 10 }
       },
-      expected: '(surname = \'Smith\' OR surname = \'Jones\') AND age > 5 AND age < 10',
-      expectedInverted: 'not(((surname = \'Smith\' and surname is not null) OR (surname = \'Jones\' and surname is not null)) AND age > 5 AND age < 10)'
+      expected: '(surname = \'Smith\' OR surname = \'Jones\') AND (age > 5 AND age < 10)',
+      expectedInverted: '((surname != \'Smith\' or surname is null) AND (surname != \'Jones\' or surname is null)) AND (age <= 5 OR age >= 10)'
     },
     {
       label: 'no where clause',


### PR DESCRIPTION
If the target table was empty, the conflicts detect was overeager (or broken, depending on your point of view). This change doesn't bother to check for conflicts if the target table is empty.