### PR TITLE
fix: Be less picky about when to create the conflicts file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,6 @@ const processUpserts = require('./process-upserts')
 const processConflicts = require('./process-conflicts')
 const processDeletes = require('./process-deletes')
 const syncChanges = require('./sync-changes')
-const generateWhereClause = require('./generate-where-clause')
 
 async function pgTelepods (options) {
   debug('Start')
@@ -25,10 +24,8 @@ async function pgTelepods (options) {
   debug('Finding deletes ...')
   await processDeletes(options)
 
-  if (await potentialConflicts(options)) {
-    debug('Finding conflicts ...')
-    await processConflicts(options)
-  }
+  debug('Finding conflicts ...')
+  await processConflicts(options)
 
   debug('Applying changes ...')
   await syncChanges(options)
@@ -51,19 +48,6 @@ async function createDirectories (options) {
     await makeDir(dir)
   }
 } // createDirectories
-
-async function potentialConflicts (options) {
-  if (!options.target.where) {
-    return false
-  }
-
-  const filter = generateWhereClause(options.target.where, 'target')
-  const countSql = `select count(*) as count from ${options.target.tableName} target where ${filter}`
-
-  const countResult = await options.client.query(countSql)
-  const potential = (countResult.rows[0].count !== '0')
-  return potential
-}
 
 function dbgOptions (options) {
   debug({

--- a/lib/process-conflicts.js
+++ b/lib/process-conflicts.js
@@ -15,6 +15,8 @@ function conflictCondition (
 }
 
 function processConflicts (options) {
+  if (!options.conflicts) return
+
   return insertUpdate(
     options,
     options.conflicts,

--- a/test/partial-table-tests-population.js
+++ b/test/partial-table-tests-population.js
@@ -14,13 +14,8 @@ function checkFileLength (outputDir, operation, filename, expectedLength) {
   const censusFile = path.resolve(outputDir, operation, filename)
   expect(fs.existsSync(censusFile)).to.equal(true)
 
-  const deletes = fs.readFileSync(censusFile, { encoding: 'utf-8' })
-  expect(deletes.split('\n').length).to.equal(expectedLength)
-}
-
-function fileNotExists (outputDir, operation, filename) {
-  const censusDeletes = path.resolve(outputDir, operation, filename)
-  expect(fs.existsSync(censusDeletes)).to.equal(false)
+  const lines = fs.readFileSync(censusFile, { encoding: 'utf-8' })
+  expect(lines.split('\n').length).to.equal(expectedLength)
 }
 
 describe('partial-table population',
@@ -127,7 +122,7 @@ describe('partial-table population',
       })
 
       it('check for conflicts csv', () => {
-        fileNotExists(firstSyncOutputDir, 'conflicts', 'census.csv')
+        checkFileLength(firstSyncOutputDir, 'conflicts', 'census.csv', 1)
       })
     })
 


### PR DESCRIPTION
Creating the conflicts file only when there are conflicts makes downstream processing much more
fiddly. This was a mistake. Easier all round if we create the conflicts file, even if it turns out
to be empty.